### PR TITLE
Update defenses.html

### DIFF
--- a/tutorial/reading_lists/defenses.html
+++ b/tutorial/reading_lists/defenses.html
@@ -118,6 +118,10 @@
 
               <li><a href="https://arxiv.org/abs/2402.06363">StruQ: Defending Against Prompt Injection with Structured
                   Queries</a></li>
+              <li><a href="https://arxiv.org/abs/2403.00867">Gradient Cuff: Detecting Jailbreak Attacks on Large Language Models by Exploring Refusal Loss Landscapes
+</a></li>
+              <li><a href="https://arxiv.org/abs/2412.18171">Token Highlighter: Inspecting and Mitigating Jailbreak Prompts for Large Language Models
+</a></li>
             </ul>
 
             <h4 class="title is-5">Guardrails</h4>


### PR DESCRIPTION
I add my two papers about how to use the LLM's gradient information to defend the jailbreak prompts.

Since I didn't find a suitable sub-class for them, I just put them in the category of inference-time-defense/prompt.

I hope these two papers will be collected since I believe they provide a clear reference for readers on how to utilize LLM's gradient information to defend the Jailbreak attacks.

